### PR TITLE
Spelling corrections and testing PR

### DIFF
--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -53,7 +53,7 @@ func TestSetExpiration(t *testing.T) {
 }
 
 func TestGetActive(t *testing.T) {
-	assert.True(t, cache.GetActive(), "Expected intial active value to be true")
+	assert.True(t, cache.GetActive(), "Expected initial active value to be true")
 }
 
 func TestSetActive(t *testing.T) {

--- a/pkg/models/root.go
+++ b/pkg/models/root.go
@@ -1,6 +1,6 @@
 package models
 
-// Root is a list of availble resource endpoints
+// Root is a list of available resource endpoints
 type Root struct {
 	Ability                 string `json:"ability"`
 	Berry                   string `json:"berry"`


### PR DESCRIPTION
Fixing 2 spelling mistakes per go report card (https://goreportcard.com/report/github.com/JoshGuarino/PokeGo#misspell) and to test being able to create PR for repo.